### PR TITLE
Ignore server trust

### DIFF
--- a/DemoApp/SimpleBrowser/BrowserViewController.swift
+++ b/DemoApp/SimpleBrowser/BrowserViewController.swift
@@ -72,7 +72,7 @@ extension BrowserViewController: WKNavigationDelegate {
         if let alert = alertForAuthentication(challenge, completionHandler) {
             presentViewController(alert, animated: true, completion: nil)
         } else {
-            completionHandler(.RejectProtectionSpace, nil)
+            completionHandler(.PerformDefaultHandling, nil)
         }
     }
 

--- a/DemoApp/SimpleBrowser/BrowserViewController.swift
+++ b/DemoApp/SimpleBrowser/BrowserViewController.swift
@@ -26,7 +26,7 @@ class BrowserViewController: ZenWebViewController {
         navigationController?.hidesBarsOnSwipe = true
         navigationController?.barHideOnSwipeGestureRecognizer.addTarget(self, action: "updateStatusBar:")
 
-        let request = NSURLRequest(URL: NSURL(string: "http://apple.com")!)
+        let request = NSURLRequest(URL: NSURL(string: "https://www.apple.com")!)
         webView.loadRequest(request)
     }
 
@@ -69,8 +69,11 @@ class BrowserViewController: ZenWebViewController {
 extension BrowserViewController: WKNavigationDelegate {
 
     func webView(webView: WKWebView, didReceiveAuthenticationChallenge challenge: NSURLAuthenticationChallenge, completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential!) -> Void) {
-        let alert = authenticationAlert(challenge, completionHandler)
-        presentViewController(alert, animated: true, completion: nil)
+        if let alert = alertForAuthentication(challenge, completionHandler) {
+            presentViewController(alert, animated: true, completion: nil)
+        } else {
+            completionHandler(.RejectProtectionSpace, nil)
+        }
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ override public func viewDidLoad() {
 ``` swift
 /// in `WKWebNavigationDelegate` object
 func webView(webView: WKWebView, didReceiveAuthenticationChallenge challenge: NSURLAuthenticationChallenge, completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential!) -> Void) {
-    if let alert = alertForAuthentication(challenge, completionHandler: completionHandler) {
+    if let alert = alertForAuthentication(challenge, completionHandler) {
         presentViewController(alert, animated: true, completion: nil)
     } else {
-        completionHandler(.RejectProtectionSpace, nil)
+        // Should call `completionHandler` if `alertForAuthentication` return `.None`.
+        completionHandler(.PerformDefaultHandling, nil)
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ override public func viewDidLoad() {
 ``` swift
 /// in `WKWebNavigationDelegate` object
 func webView(webView: WKWebView, didReceiveAuthenticationChallenge challenge: NSURLAuthenticationChallenge, completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential!) -> Void) {
-    let alert = alertForAuthentication(challenge, completionHandler)
-    presentViewController(alert, animated: true, completion: nil)
+    if let alert = alertForAuthentication(challenge, completionHandler: completionHandler) {
+        presentViewController(alert, animated: true, completion: nil)
+    } else {
+        completionHandler(.RejectProtectionSpace, nil)
+    }
 }
 ```
 

--- a/WebKitPlus/Functions.swift
+++ b/WebKitPlus/Functions.swift
@@ -1,23 +1,29 @@
 import UIKit
 
-public func alertForAuthentication(challenge: NSURLAuthenticationChallenge, completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential!) -> Void) -> UIAlertController {
+public func alertForAuthentication(challenge: NSURLAuthenticationChallenge, completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential!) -> Void) -> UIAlertController? {
     let space = challenge.protectionSpace
-    let alert = UIAlertController(title: "\(space.`protocol`!)://\(space.host):\(space.port)", message: space.realm, preferredStyle: .Alert)
-    alert.addTextFieldWithConfigurationHandler {
-        $0.placeholder = localizedString("user")
-    }
-    alert.addTextFieldWithConfigurationHandler {
-        $0.placeholder = localizedString("password")
-        $0.secureTextEntry = true
-    }
-        alert.addAction(UIAlertAction(title: localizedString("Cancel"), style: .Cancel) { _ in
+    let alert: UIAlertController?
+    if space.authenticationMethod == NSURLAuthenticationMethodServerTrust {
+        // ignore Server Trust.
+        alert = nil
+    } else {
+        alert = UIAlertController(title: "\(space.`protocol`!)://\(space.host):\(space.port)", message: space.realm, preferredStyle: .Alert)
+        alert?.addTextFieldWithConfigurationHandler {
+            $0.placeholder = localizedString("user")
+        }
+        alert?.addTextFieldWithConfigurationHandler {
+            $0.placeholder = localizedString("password")
+            $0.secureTextEntry = true
+        }
+        alert?.addAction(UIAlertAction(title: localizedString("Cancel"), style: .Cancel) { _ in
             completionHandler(.CancelAuthenticationChallenge, nil)
         })
-        alert.addAction(UIAlertAction(title: localizedString("OK"), style: .Default) { _ in
-            let textFields = alert.textFields as! [UITextField]
-            let credential = NSURLCredential(user: textFields[0].text, password: textFields[1].text, persistence: .ForSession)
+        alert?.addAction(UIAlertAction(title: localizedString("OK"), style: .Default) { _ in
+            let textFields = alert!.textFields as! [UITextField]
+            let credential = NSURLCredential(user: textFields[0].text!, password: textFields[1].text!, persistence: .ForSession)
             completionHandler(.UseCredential, credential)
         })
+    }
     return alert
 }
 

--- a/WebKitPlus/Functions.swift
+++ b/WebKitPlus/Functions.swift
@@ -1,12 +1,10 @@
 import UIKit
 
+/// Return UIAlertController? that input form for user credential if needed.
 public func alertForAuthentication(challenge: NSURLAuthenticationChallenge, completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential!) -> Void) -> UIAlertController? {
     let space = challenge.protectionSpace
     let alert: UIAlertController?
-    if space.authenticationMethod == NSURLAuthenticationMethodServerTrust {
-        // ignore Server Trust.
-        alert = nil
-    } else {
+    if space.isUserCredential {
         alert = UIAlertController(title: "\(space.`protocol`!)://\(space.host):\(space.port)", message: space.realm, preferredStyle: .Alert)
         alert?.addTextFieldWithConfigurationHandler {
             $0.placeholder = localizedString("user")
@@ -23,8 +21,24 @@ public func alertForAuthentication(challenge: NSURLAuthenticationChallenge, comp
             let credential = NSURLCredential(user: textFields[0].text!, password: textFields[1].text!, persistence: .ForSession)
             completionHandler(.UseCredential, credential)
         })
+    } else {
+        alert = nil
     }
     return alert
+}
+
+extension NSURLProtectionSpace {
+
+    private var isUserCredential: Bool {
+        if let p = `protocol` where p == "http" && authenticationMethod == NSURLAuthenticationMethodDefault {
+            return true
+        } else if authenticationMethod == NSURLAuthenticationMethodHTTPBasic || authenticationMethod == NSURLAuthenticationMethodHTTPDigest {
+            return true
+        } else {
+            return false
+        }
+    }
+
 }
 
 public func alertForNavigationFailed(error: NSError) -> UIAlertController? {


### PR DESCRIPTION
iOS 9だと`webView(_:, didReceiveAuthenticationChallenge:, completionHandler)`がhttpsのときも呼ばれる．
Server trustの場合はクライアントで特になにかをする必要は無いので無視をする．