### PR TITLE
Deprecate alert(for:completion:) and alert(for:)

### DIFF
--- a/DemoApp/SimpleBrowser/BrowserViewController.swift
+++ b/DemoApp/SimpleBrowser/BrowserViewController.swift
@@ -72,7 +72,7 @@ class BrowserViewController: ZenWebViewController {
 extension BrowserViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        guard let alert = alert(for: challenge, completion: completionHandler) else {
+        guard let alert = UIAlertController(for: challenge, completion: completionHandler) else {
             // Should call `completionHandler` if `alertForAuthentication` return `.None`.
             completionHandler(.performDefaultHandling, nil)
             return

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ override public func viewDidLoad() {
 ```
 
 ### Authentication in navigation
-`alert(for:completion:)` function create `UIAlertController` for input informations of authenticcation.
+Use `UIAlertController (for: completion :)` to input informations of authentication.
 
 ``` swift
 /// in `WKNavigationDelegate` object
 func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-    guard let alert = alert(for: challenge, completion: completionHandler) else {
+    guard let alert = UIAlertController(for: challenge, completion: completionHandler) else {
         // Should call `completionHandler` if `alertForAuthentication` return `.None`.
         completionHandler(.performDefaultHandling, nil)
         return

--- a/Sources/WebKitPlus/Functions.swift
+++ b/Sources/WebKitPlus/Functions.swift
@@ -30,21 +30,6 @@ public func alertForAuthentication(_ challenge: URLAuthenticationChallenge, _ co
     fatalError()
 }
 
-extension URLProtectionSpace {
-
-    fileprivate var isUserCredential: Bool {
-        switch authenticationMethod {
-        case NSURLAuthenticationMethodDefault where `protocol` == "http":
-            return true
-        case NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodHTTPDigest:
-            return true
-        default:
-            return false
-        }
-    }
-
-}
-
 public func alert(for error: NSError) -> UIAlertController? {
     if error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled { return nil }
     // Ignore WebKitErrorFrameLoadInterruptedByPolicyChange

--- a/Sources/WebKitPlus/Functions.swift
+++ b/Sources/WebKitPlus/Functions.swift
@@ -3,27 +3,25 @@ import UIKit
 /// Return UIAlertController? that input form for user credential if needed.
 public func alert(for challenge: URLAuthenticationChallenge, completion: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> UIAlertController? {
     let space = challenge.protectionSpace
-    let alert: UIAlertController?
-    if space.isUserCredential {
-        alert = UIAlertController(title: "\(space.`protocol`!)://\(space.host):\(space.port)", message: space.realm, preferredStyle: .alert)
-        alert?.addTextField {
-            $0.placeholder = localizedString(for: "user")
-        }
-        alert?.addTextField {
-            $0.placeholder = localizedString(for: "password")
-            $0.isSecureTextEntry = true
-        }
-        alert?.addAction(UIAlertAction(title: localizedString(for: "Cancel"), style: .cancel) { _ in
-            completion(.cancelAuthenticationChallenge, nil)
-        })
-        alert?.addAction(UIAlertAction(title: localizedString(for: "OK"), style: .default) { _ in
-            let textFields = alert!.textFields!
-            let credential = URLCredential(user: textFields[0].text!, password: textFields[1].text!, persistence: .forSession)
-            completion(.useCredential, credential)
-        })
-    } else {
-        alert = nil
+    guard space.isUserCredential else {
+        return nil
     }
+    let alert = UIAlertController(title: "\(space.`protocol`!)://\(space.host):\(space.port)", message: space.realm, preferredStyle: .alert)
+    alert.addTextField {
+        $0.placeholder = localizedString(for: "user")
+    }
+    alert.addTextField {
+        $0.placeholder = localizedString(for: "password")
+        $0.isSecureTextEntry = true
+    }
+    alert.addAction(UIAlertAction(title: localizedString(for: "Cancel"), style: .cancel) { _ in
+        completion(.cancelAuthenticationChallenge, nil)
+    })
+    alert.addAction(UIAlertAction(title: localizedString(for: "OK"), style: .default) { _ in
+        let textFields = alert.textFields!
+        let credential = URLCredential(user: textFields[0].text!, password: textFields[1].text!, persistence: .forSession)
+        completion(.useCredential, credential)
+    })
     return alert
 }
 

--- a/Sources/WebKitPlus/Functions.swift
+++ b/Sources/WebKitPlus/Functions.swift
@@ -33,11 +33,12 @@ public func alertForAuthentication(_ challenge: URLAuthenticationChallenge, _ co
 extension URLProtectionSpace {
 
     fileprivate var isUserCredential: Bool {
-        if let p = `protocol` , p == "http" && authenticationMethod == NSURLAuthenticationMethodDefault {
+        switch authenticationMethod {
+        case NSURLAuthenticationMethodDefault where `protocol` == "http":
             return true
-        } else if authenticationMethod == NSURLAuthenticationMethodHTTPBasic || authenticationMethod == NSURLAuthenticationMethodHTTPDigest {
+        case NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodHTTPDigest:
             return true
-        } else {
+        default:
             return false
         }
     }

--- a/Sources/WebKitPlus/Functions.swift
+++ b/Sources/WebKitPlus/Functions.swift
@@ -1,49 +1,25 @@
 import UIKit
 
 /// Return UIAlertController? that input form for user credential if needed.
+@available(*, deprecated, renamed: "UIAlertController(for:completion:)")
 public func alert(for challenge: URLAuthenticationChallenge, completion: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> UIAlertController? {
-    let space = challenge.protectionSpace
-    guard space.isUserCredential else {
-        return nil
-    }
-    let alert = UIAlertController(title: "\(space.`protocol`!)://\(space.host):\(space.port)", message: space.realm, preferredStyle: .alert)
-    alert.addTextField {
-        $0.placeholder = localizedString(for: "user")
-    }
-    alert.addTextField {
-        $0.placeholder = localizedString(for: "password")
-        $0.isSecureTextEntry = true
-    }
-    alert.addAction(UIAlertAction(title: localizedString(for: "Cancel"), style: .cancel) { _ in
-        completion(.cancelAuthenticationChallenge, nil)
-    })
-    alert.addAction(UIAlertAction(title: localizedString(for: "OK"), style: .default) { _ in
-        let textFields = alert.textFields!
-        let credential = URLCredential(user: textFields[0].text!, password: textFields[1].text!, persistence: .forSession)
-        completion(.useCredential, credential)
-    })
-    return alert
+    return UIAlertController(for: challenge, completion: completion)
 }
 
-@available(*, unavailable, renamed: "alert(for:completion:)")
+@available(*, unavailable, renamed: "UIAlertController(for:completion:)")
 public func alertForAuthentication(_ challenge: URLAuthenticationChallenge, _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> UIAlertController? {
     fatalError()
 }
 
+@available(*, deprecated, renamed: "UIAlertController(error:)")
 public func alert(for error: NSError) -> UIAlertController? {
-    if error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled { return nil }
-    // Ignore WebKitErrorFrameLoadInterruptedByPolicyChange
-    if error.domain == "WebKitErrorDomain" && error.code == 102 { return nil }
-
-    let title = error.userInfo[NSURLErrorFailingURLStringErrorKey] as? String
-    let message = error.localizedDescription
-    let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-    alert.addAction(UIAlertAction(title: localizedString(for: "OK"), style: .default) { _ in })
-    return alert
+    return UIAlertController(error: error)
 }
 
-@available(*, unavailable, renamed: "alert(for:)")
-public func alertForNavigationFailed(_ error: NSError) -> UIAlertController? { fatalError() }
+@available(*, unavailable, renamed: "UIAlertController(error:)")
+public func alertForNavigationFailed(_ error: NSError) -> UIAlertController? {
+    fatalError()
+}
 
 func localizedString(for key: String) -> String {
     let bundle = Bundle(for: WKUIDelegatePlus.self)

--- a/Sources/WebKitPlus/UIAlertController+Init.swift
+++ b/Sources/WebKitPlus/UIAlertController+Init.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+extension UIAlertController {
+    public convenience init?(for challenge: URLAuthenticationChallenge, completion: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        let space = challenge.protectionSpace
+        guard space.isUserCredential else {
+            return nil
+        }
+        self.init(title: "\(space.`protocol`!)://\(space.host):\(space.port)", message: space.realm, preferredStyle: .alert)
+        self.addTextField {
+            $0.placeholder = localizedString(for: "user")
+        }
+        self.addTextField {
+            $0.placeholder = localizedString(for: "password")
+            $0.isSecureTextEntry = true
+        }
+        self.addAction(UIAlertAction(title: localizedString(for: "Cancel"), style: .cancel) { _ in
+            completion(.cancelAuthenticationChallenge, nil)
+        })
+        self.addAction(UIAlertAction(title: localizedString(for: "OK"), style: .default) { [weak self] _ in
+            let textFields = self!.textFields!
+            let credential = URLCredential(user: textFields[0].text!, password: textFields[1].text!, persistence: .forSession)
+            completion(.useCredential, credential)
+        })
+    }
+
+    public convenience init?(error: NSError) {
+        if error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+            return nil
+        }
+        // Ignore WebKitErrorFrameLoadInterruptedByPolicyChange
+        if error.domain == "WebKitErrorDomain" && error.code == 102 {
+            return nil
+        }
+
+        let title = error.userInfo[NSURLErrorFailingURLStringErrorKey] as? String
+        let message = error.localizedDescription
+        self.init(title: title, message: message, preferredStyle: .alert)
+        self.addAction(UIAlertAction(title: localizedString(for: "OK"), style: .default) { _ in })
+    }
+}

--- a/Sources/WebKitPlus/URLProtectionSpace+UserCredential.swift
+++ b/Sources/WebKitPlus/URLProtectionSpace+UserCredential.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension URLProtectionSpace {
+    internal var isUserCredential: Bool {
+        switch authenticationMethod {
+        case NSURLAuthenticationMethodDefault where `protocol` == "http":
+            return true
+        case NSURLAuthenticationMethodHTTPBasic, NSURLAuthenticationMethodHTTPDigest:
+            return true
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
- Use UIAlertController.init as extension
- Set available attribute